### PR TITLE
specify context dimensions and code cleanup

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,11 +1,3 @@
-body {
-  height: 100vh;
-}
-
-#root {
-  height: 100%
-}
-
 .main {
   display: flex;
   justify-content: center;
@@ -13,18 +5,12 @@ body {
   height: 100%;
 }
 
-.video-box {
-  /* border: 2px solid black; */
-  height: 50%;
-  width: 50%;
-}
-
 #canvas {
-  height: 100vh;
-  width: 100vw;
+  height: 100%;
+  width: 100%;
 }
 
 #video {
   position: absolute;
-  max-height: 50%;
+  max-height: 80%;
 }

--- a/src/App.css
+++ b/src/App.css
@@ -5,11 +5,6 @@
   height: 100%;
 }
 
-#canvas {
-  height: 100%;
-  width: 100%;
-}
-
 #video {
   position: absolute;
   max-height: 80%;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,87 +1,48 @@
-import React, { useEffect } from 'react';
-import logo from './logo.svg';
 import './App.css';
-import { useRef, useState } from 'react'
-
-interface Dimensions {
-  h: number;
-  w: number;
-}
-
-function computeFrame() {
-  
-}
+import { useRef, useState, useEffect, useCallback } from 'react';
 
 function App() {
-  const [videoDimensions, setVideoDimensions] = useState<Dimensions>({ h: 0, w: 0 })
-  const [canvasDimensions, setCanvasDimensions] = useState<Dimensions>({ h: 0, w: 0})
-  const [counter, setCounter] = useState(0);
+  const [_, setDummyState] = useState(false);
   const videoRef = useRef<HTMLVideoElement>(null);
   const canvasRef = useRef<HTMLCanvasElement>(null);
-  
+
   const ctx = canvasRef.current?.getContext('2d');
 
-  console.log(canvasDimensions);
-  console.log(window.innerHeight, window.innerWidth)
-
-  const setAllDimensions = () => {
-    if (!videoRef.current || !canvasRef.current) return;
-
-    const videoRect = videoRef.current.getBoundingClientRect();
-    const canvasRect = canvasRef.current.getBoundingClientRect();
-    setVideoDimensions({ h: videoRect.height, w: videoRect.width})
-    // setCanvasDimensions({ h: window.innerHeight, w: window })
-    setCanvasDimensions({ h: canvasRect.height, w: canvasRect.width })
-  }
-
-  // runs once when the component first renders
-  useEffect(function setup(){
-    setAllDimensions()
-    
-    window.addEventListener('resize', () => {
-      setAllDimensions()
-    });
-
-    videoRef.current?.addEventListener('play', () =>
-      videoRef.current?.requestVideoFrameCallback(updateCanvas)
-    ); 
+  const rerender = useCallback(() => {
+    setDummyState((prevState) => !prevState);
+    videoRef.current?.requestVideoFrameCallback(rerender);
   }, []);
 
-  videoRef.current?.requestVideoFrameCallback(updateCanvas);
-  function updateCanvas() {
-    // ctx?.drawImage(videoRef.current!, 0, 0, width, height);
-    setCounter((counter) => counter+1);
-  }
-
-  if (ctx) {
-    ctx.canvas.width = canvasDimensions.w;
-    ctx.canvas.height = canvasDimensions.h
-  }
-  // drawImage(image, sx, sy, sWidth, sHeight, dx, dy, dWidth, dHeight)
-  ctx?.drawImage(
-    videoRef.current!,
-    0, 0,
-     videoDimensions.w,videoDimensions.h,
-    0, 0,
-     canvasDimensions.w,canvasDimensions.h,
+  // runs once when the component first renders
+  useEffect(
+    function setup() {
+      videoRef.current?.addEventListener('play', () =>
+        videoRef.current?.requestVideoFrameCallback(rerender)
+      );
+    },
+    [rerender]
   );
 
+  if (videoRef.current) {
+    ctx?.drawImage(videoRef.current, 0, 0);
+  }
+
   return (
-    <div className="main"
-   >
-      <canvas id="canvas" 
-       ref={canvasRef}
-      // width={canvasDimensions.w}
-      // height={canvasDimensions.h}
+    <div className='main'>
+      <canvas
+        id='canvas'
+        ref={canvasRef}
+        width={window.innerWidth}
+        height={window.innerHeight}
       ></canvas>
       <video
         ref={videoRef}
-        id="video"
+        id='video'
         controls
         muted
         loop
         src={require('./assets/videoplayback.mp4')}
-        />
+      />
     </div>
   );
 }


### PR DESCRIPTION
Very weird, but the canvas element has it's own dimensions which are separate from the canvas context that we draw on. So specifying the width/height on the element (or setting the width/height on the context in code) is the proper way to get them aligned. There's a new issue about aspect ratio now, but I don't think that should affect our convolution calculations too much

Aside from the fix above, just general code clean up