### PR TITLE
refactor to efficiently extract frame data

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,71 +1,11 @@
 import './App.css';
-import { useRef, useState, useEffect, useCallback } from 'react';
-
-function computeBacklightFrame(frame?: ImageData) {
-  if (!frame) return;
-  console.log(frame);
-}
+import BacklightSimulator from './BacklightSimulator';
 
 function App() {
-  const [_, setDummyState] = useState(false);
-  const videoRef = useRef<HTMLVideoElement>(null);
-  const canvasRef = useRef<HTMLCanvasElement>(null); // only to get the current video frame
-  const contextRef = useRef<CanvasRenderingContext2D | null>();
-
-  const handleFrame = useCallback(() => {
-    // grab the current frame
-    contextRef.current?.drawImage(
-      videoRef.current!,
-      0,
-      0,
-      window.innerWidth,
-      window.innerHeight
-    );
-    const frameData = contextRef.current?.getImageData(
-      0,
-      0,
-      window.innerWidth,
-      window.innerHeight
-    );
-
-    // handle fancy logic here
-    const backlightFrame = computeBacklightFrame(frameData);
-    // draw the backlight frame onto the context
-
-    setDummyState((prev) => !prev); // hack to force rerender
-    videoRef.current?.requestVideoFrameCallback(handleFrame);
-  }, []);
-
-  // runs once when the component first renders
-  useEffect(
-    function setup() {
-      // set the context
-      contextRef.current = canvasRef.current?.getContext('2d', {
-        willReadFrequently: true,
-      });
-      videoRef.current?.addEventListener('play', () =>
-        videoRef.current?.requestVideoFrameCallback(handleFrame)
-      );
-    },
-    [handleFrame]
-  );
-
   return (
-    <div className='main'>
-      <canvas
-        ref={canvasRef}
-        width={window.innerWidth}
-        height={window.innerHeight}
-      ></canvas>
-      <video
-        ref={videoRef}
-        id='video'
-        controls
-        muted
-        loop
-        src={require('./assets/videoplayback.mp4')}
-      />
-    </div>
+    <>
+      <BacklightSimulator />
+    </>
   );
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,36 +1,58 @@
 import './App.css';
 import { useRef, useState, useEffect, useCallback } from 'react';
 
+function computeBacklightFrame(frame?: ImageData) {
+  if (!frame) return;
+  console.log(frame);
+}
+
 function App() {
   const [_, setDummyState] = useState(false);
   const videoRef = useRef<HTMLVideoElement>(null);
-  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const canvasRef = useRef<HTMLCanvasElement>(null); // only to get the current video frame
+  const contextRef = useRef<CanvasRenderingContext2D | null>();
 
-  const ctx = canvasRef.current?.getContext('2d');
+  const handleFrame = useCallback(() => {
+    // grab the current frame
+    contextRef.current?.drawImage(
+      videoRef.current!,
+      0,
+      0,
+      window.innerWidth,
+      window.innerHeight
+    );
+    const frameData = contextRef.current?.getImageData(
+      0,
+      0,
+      window.innerWidth,
+      window.innerHeight
+    );
 
-  const rerender = useCallback(() => {
-    setDummyState((prevState) => !prevState);
-    videoRef.current?.requestVideoFrameCallback(rerender);
+    // handle fancy logic here
+    const backlightFrame = computeBacklightFrame(frameData);
+    // draw the backlight frame onto the context
+
+    setDummyState((prev) => !prev); // hack to force rerender
+    videoRef.current?.requestVideoFrameCallback(handleFrame);
   }, []);
 
   // runs once when the component first renders
   useEffect(
     function setup() {
+      // set the context
+      contextRef.current = canvasRef.current?.getContext('2d', {
+        willReadFrequently: true,
+      });
       videoRef.current?.addEventListener('play', () =>
-        videoRef.current?.requestVideoFrameCallback(rerender)
+        videoRef.current?.requestVideoFrameCallback(handleFrame)
       );
     },
-    [rerender]
+    [handleFrame]
   );
-
-  if (videoRef.current) {
-    ctx?.drawImage(videoRef.current, 0, 0);
-  }
 
   return (
     <div className='main'>
       <canvas
-        id='canvas'
         ref={canvasRef}
         width={window.innerWidth}
         height={window.innerHeight}

--- a/src/BacklightSimulator.tsx
+++ b/src/BacklightSimulator.tsx
@@ -1,8 +1,7 @@
 import { useCallback, useEffect, useRef } from 'react';
 const videoSrc = require('./assets/videoplayback.mp4');
 
-const computeBacklightFrame = (frame: ImageBitmap) => {
-  console.log(frame);
+const computeBacklightFrame = (frame: ImageData) => {
   return frame;
 };
 
@@ -19,19 +18,13 @@ export default function BacklightSimulator(props: Props) {
       ctx: CanvasRenderingContext2D
     ) => {
       ctx.clearRect(0, 0, window.innerWidth, window.innerHeight);
-      // could maybe downsample here
-      createImageBitmap(video, { resizeQuality: 'low' }).then((data) => {
-        const backlightFrame = computeBacklightFrame(data);
-        ctx.drawImage(
-          backlightFrame,
-          0,
-          0,
-          window.innerWidth,
-          window.innerHeight
-        );
-        data.close();
-        video.requestVideoFrameCallback(() => handleFrame(video, canvas, ctx));
-      });
+      ctx.drawImage(video, 0, 0, video.videoWidth, video.videoHeight);
+
+      const frame = ctx.getImageData(0, 0, canvas.width, canvas.height);
+      const backlightFrame = computeBacklightFrame(frame);
+      ctx.putImageData(backlightFrame, 0, 0);
+
+      video.requestVideoFrameCallback(() => handleFrame(video, canvas, ctx));
     },
     []
   );

--- a/src/BacklightSimulator.tsx
+++ b/src/BacklightSimulator.tsx
@@ -1,0 +1,77 @@
+import { useCallback, useEffect, useRef } from 'react';
+const videoSrc = require('./assets/videoplayback.mp4');
+
+const computeBacklightFrame = (frame: ImageBitmap) => {
+  console.log(frame);
+  return frame;
+};
+
+interface Props {}
+
+export default function BacklightSimulator(props: Props) {
+  const videoRef = useRef<HTMLVideoElement>(null);
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  const handleFrame = useCallback(
+    (
+      video: HTMLVideoElement,
+      canvas: HTMLCanvasElement,
+      ctx: CanvasRenderingContext2D
+    ) => {
+      ctx.clearRect(0, 0, window.innerWidth, window.innerHeight);
+      // could maybe downsample here
+      createImageBitmap(video, { resizeQuality: 'low' }).then((data) => {
+        const backlightFrame = computeBacklightFrame(data);
+        ctx.drawImage(
+          backlightFrame,
+          0,
+          0,
+          window.innerWidth,
+          window.innerHeight
+        );
+        data.close();
+        video.requestVideoFrameCallback(() => handleFrame(video, canvas, ctx));
+      });
+    },
+    []
+  );
+
+  useEffect(
+    function setup() {
+      const video = videoRef.current;
+      const canvas = canvasRef.current;
+      if (!video || !canvas) return;
+
+      const ctx = canvas.getContext('2d', { willReadFrequently: true });
+      if (!ctx) return;
+
+      const startFrameProcessing = () =>
+        video.requestVideoFrameCallback(() => handleFrame(video, canvas, ctx));
+      video.addEventListener('play', startFrameProcessing);
+
+      const handleResize = () => {
+        canvas.width = window.innerWidth;
+        canvas.height = window.innerHeight;
+      };
+      window.addEventListener('resize', handleResize);
+      handleResize();
+
+      return () => {
+        video.removeEventListener('play', startFrameProcessing);
+        window.removeEventListener('resize', handleResize);
+      };
+    },
+    [handleFrame]
+  );
+
+  return (
+    <div className='main'>
+      <canvas
+        ref={canvasRef}
+        width={window.innerWidth}
+        height={window.innerHeight}
+      ></canvas>
+      <video ref={videoRef} id='video' src={videoSrc} muted loop controls />
+    </div>
+  );
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,7 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
@@ -20,7 +16,5 @@
     "noEmit": true,
     "jsx": "react-jsx"
   },
-  "include": [
-    "src"
-  ]
+  "include": ["src"]
 }


### PR DESCRIPTION
this PR adds some small refactoring here to reuse the same reference to the canvas context across react renders with a ref and the `willReadFrequently` option set to true. I'm able to play the demon slayer video about 1.5 times and console log the frame data before we OOM.

we're OOM-ing because each call to `getImageData` creates a new variable on the heap until we OOM. it'd be nice if there were some easy way to pass a pointer instead to getImageData so it could instead just keep repopulating the same refernece.